### PR TITLE
Fix mem leak in Realloc

### DIFF
--- a/MemoryAllocator/src/Allocator.cpp
+++ b/MemoryAllocator/src/Allocator.cpp
@@ -468,7 +468,7 @@ void** Allocator::realloc(void* ptr, size_t size){
             return nullptr;
         }
         memcpy(*newBlock, savedData, dataSize);
-        delete savedData;
+        delete[] savedData;
         return newBlock;    
     }
 }


### PR DESCRIPTION
The temporary holding for the data stored in the original chunk was not properly deleted due to it being treated as an array