### PR TITLE
Fix memoryPool double allocation leak

### DIFF
--- a/MemoryAllocator/include/Allocator.hpp
+++ b/MemoryAllocator/include/Allocator.hpp
@@ -6,7 +6,7 @@ class Allocator {
     private:
         int memorySize;
         int freeMemory;
-        static inline uint8_t* memoryPool;
+        uint8_t* memoryPool;
         Chunk* occHead = nullptr;
         Chunk* freeHead = nullptr;
         


### PR DESCRIPTION
The allocator would leak memory due to the memory pool being declared as a static variable causing the destructor to remove the memory pool for all existing memory pools. 

Fixes #19