### PR TITLE
Implement improved iterator for Free and Realloc

### DIFF
--- a/MemoryAllocator/src/Allocator.cpp
+++ b/MemoryAllocator/src/Allocator.cpp
@@ -221,7 +221,7 @@ void Allocator::free(void* ptr){
         if(newFree->startLoc == ptr){
             break;
         }
-        newFree = newFree->next;
+        newFree = newFree->AbsNext;
     }
     if(newFree == nullptr){
         return;
@@ -324,7 +324,7 @@ void** Allocator::realloc(void* ptr, size_t size){
         return nullptr;
     }
     while (target->startLoc != ptr){
-        target = target->next;
+        target = target->AbsNext;
         if (target == ptr){
             break;
         }


### PR DESCRIPTION
Using information found in #30 it is clear that iterating via absNext is much faster than through the next variable despite next on average needing less iterations to find a variable. Even in the worst case scenario where every other variable is a free chunk absNext still vastly outperforms iterating via next at higher chunk counts (most likely due to optimizations calculated by the compiler).

New:
<img width="1038" height="271" alt="image" src="https://github.com/user-attachments/assets/fdceac0d-8ef5-4791-b09d-53911b175946" />

Old:
<img width="922" height="215" alt="image" src="https://github.com/user-attachments/assets/25c6365a-2f89-47eb-bc2e-7eed7ce00b6d" />
