### PR TITLE
Fix malloc error

### DIFF
--- a/MemoryAllocator/src/Allocator.cpp
+++ b/MemoryAllocator/src/Allocator.cpp
@@ -160,7 +160,7 @@ void** Allocator::malloc(size_t size)
         freeCurrent->AbsPrev = newChunk;
     }
     else{
-        if(freeCurrent->AbsPrev->next != nullptr){
+        if(freeCurrent->AbsPrev != nullptr && freeCurrent->AbsPrev->next != nullptr){
             freeCurrent->AbsPrev->next->prev = newChunk;
         }
         // Insert newChunk into the occupied list by using freeCurrent as the reference


### PR DESCRIPTION
The program would attempt to access a value from a nullptr which would cause a segmentaiton fault. This was a result of not considering that a free chunk may occur at the first position in an allocator.