### PR TITLE
Remove the ability to use of implicit special member functions

### DIFF
--- a/allocatorRoot/include/memoryAllocator/allocator.hpp
+++ b/allocatorRoot/include/memoryAllocator/allocator.hpp
@@ -55,6 +55,11 @@ class Allocator {
         
     public:
         Allocator(std::size_t numBytes);
+        Allocator (const Allocator & other) = delete; // copy constructor
+        Allocator (Allocator && other) = delete; // move constructor
+        Allocator & operator=(const Allocator & other) = delete; // copy assignment
+        Allocator & operator=(Allocator && other) = delete; // move assignment
+        
         ~Allocator();
         /*
         * Returns a Chunk* that points to the first free chunk.

--- a/allocatorRoot/include/memoryAllocator/stl.hpp
+++ b/allocatorRoot/include/memoryAllocator/stl.hpp
@@ -7,7 +7,11 @@ class StlAllocator{
 public:
   using value_type = T;
 
-  explicit StlAllocator(std::size_t Sz = 1024) : alloc(std::make_shared<Allocator>(Sz*sizeof(T))) {}
+  StlAllocator (const StlAllocator & other) = delete; // copy constructor
+  StlAllocator (StlAllocator && other) = delete; // move constructor
+  StlAllocator & operator=(const StlAllocator & other) = delete; // copy assignment
+  StlAllocator & operator=(StlAllocator && other) = delete; // move assignment
+  explicit StlAllocator(std::size_t blockCount = 1024) : alloc(std::make_shared<Allocator>(blockCount*sizeof(T))) {}
   /*
   * Allocates a chunk of {n * sizeof(T)} bytes and returns a T* to the chunk.
   * T is the datatype established during the creation of the allocator.

--- a/allocatorRoot/tests/stl.cpp
+++ b/allocatorRoot/tests/stl.cpp
@@ -70,7 +70,6 @@ TEST(AllocatorSTL, STLmalloc){
   for(int i = 0; i < 100; i++){
     GTEST_ASSERT_EQ(vec.at(i), i);
   }
-  StlAllocator<int> alloc = vec.get_allocator();
 }
 
 TEST(AllocatorSTL, STLtestConnections){


### PR DESCRIPTION
Made it more clear that the amount of bytes allocated to the Stl allocator is 1024 blocks of size T not 1024 bytes.